### PR TITLE
Add informative exception when required data is missing (unexpectedly NaN)

### DIFF
--- a/code/classes/exceptions.py
+++ b/code/classes/exceptions.py
@@ -1,0 +1,5 @@
+class MissingData(Exception):
+    """Raised when required data is missing (unexpectedly NaN)"""
+
+    def __init__(self, what, year, index):
+        super().__init__(f"Missing data: {what} for year {year} (index {index})")


### PR DESCRIPTION
I was trying to run demo.ipynb with the parameters laid out in the notebook (starting from 2023), but this produded bad output (a lot of NaNs). A bit of digging revealed that this was because the potential GDP and potential GDP growth values are missing for 2023. It would have been a bit easier to debug this if the missing data caused an exception of some sort, so I propose to add one here.